### PR TITLE
Make sure we respect nil values with coercion. See #2897

### DIFF
--- a/lib/logstash/filters/grok.rb
+++ b/lib/logstash/filters/grok.rb
@@ -319,9 +319,9 @@
       matched = false
       groks.each do |grok|
         # Convert anything else to string (number, hash, etc)
-        matched = grok.match_and_capture(input.to_s) do |field, value|
+        matched = grok.match_and_capture(input.to_s) do |field, coerced_value, original_value|
           matched = true
-          handle(field, value, event)
+          handle(field, coerced_value, original_value, event)
         end
         break if matched and @break_on_match
       end
@@ -329,20 +329,20 @@
     end
   
     private
-    def handle(field, value, event)
-      return if (value.nil? || (value.is_a?(String) && value.empty?)) unless @keep_empty_captures
+    def handle(field, coerced_value, original_value, event)
+      return if (original_value.nil? || (original_value.is_a?(String) && original_value.empty?)) unless @keep_empty_captures
   
       if @overwrite.include?(field)
-        event[field] = value
+        event[field] = coerced_value
       else
         v = event[field]
         if v.nil?
-          event[field] = value
+          event[field] = coerced_value
         elsif v.is_a?(Array)
-          event[field] << value
+          event[field] << coerced_value
         elsif v.is_a?(String)
           # Promote to array since we aren't overwriting.
-          event[field] = [v, value]
+          event[field] = [v, coerced_value]
         end
       end
     end

--- a/logstash-filter-grok.gemspec
+++ b/logstash-filter-grok.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   # Gem dependencies
   s.add_runtime_dependency "logstash-core", '>= 1.4.0', '< 2.0.0'
 
-  s.add_runtime_dependency 'jls-grok', '~> 0.11.1'
+  s.add_runtime_dependency 'jls-grok', '~> 0.11.2'
   s.add_runtime_dependency 'logstash-patterns-core'
 
   s.add_development_dependency 'logstash-devutils'

--- a/spec/filters/grok_spec.rb
+++ b/spec/filters/grok_spec.rb
@@ -702,4 +702,49 @@ describe LogStash::Filters::Grok do
     end
   end
 
+  describe  "grok with nil coerced value" do
+    config <<-CONFIG
+      filter {
+        grok {
+          match => { "message" => "test (N/A|%{BASE10NUM:duration:float}ms)" }
+        }
+      }
+    CONFIG
+
+    sample "test 28.4ms" do
+      insist { subject["duration"] } == 28.4
+      insist { subject["tags"] }.nil?
+    end
+
+    sample "test N/A" do
+      insist { subject["duration"] }.nil?
+      insist { subject["tags"] }.nil?
+    end
+
+    sample "test abc" do
+      insist { subject["duration"] }.nil?
+      insist { subject["tags"] } == ["_grokparsefailure"]
+    end
+  end
+
+  describe  "grok with no coercion" do
+    config <<-CONFIG
+      filter {
+        grok {
+          match => { "message" => "test (N/A|%{BASE10NUM:duration}ms)" }
+        }
+      }
+    CONFIG
+
+    sample "test 28.4ms" do
+      insist { subject["duration"] } == "28.4"
+      insist { subject["tags"] }.nil?
+    end
+
+    sample "test N/A" do
+      insist { subject["duration"] }.nil?
+      insist { subject["tags"] }.nil?
+    end
+  end
+
 end


### PR DESCRIPTION
This fixes a regression we introduced with the grok optimization changes. See https://github.com/elastic/logstash/issues/2897 for details

```
# 1.4.2
$ ./logstash-1.4.2/bin/logstash --config testcase.conf 
{"message":"test N/A"}
{"message":"test 24.8ms","duration":24.8}

# 1.5.0.rc2
$ ./logstash-1.5.0.rc2/bin/logstash --config testcase.conf
{"message":"test N/A","duration":0.0}
{"message":"test 24.8ms","duration":24.8}
```

I ran the tests by pointing to my local gem from the source (in Gemfile)

```
suyog@machine:~/ws/ls_plugins/logstash-filter-grok (fix/2897)$ bundle exec rspec
Using Accessor#strict_set for specs
Run options: exclude {:redis=>true, :socket=>true, :performance=>true, :couchdb=>true, :elasticsearch=>true, :elasticsearch_secure=>true, :broken=>true, :export_cypher=>true, :integration=>true, :windows=>true}
.........................................................................................

Finished in 3.24 seconds
89 examples, 0 failures

Randomized with seed 6841
```