### PR TITLE
Fix example for patterns_dir

### DIFF
--- a/lib/logstash/filters/grok.rb
+++ b/lib/logstash/filters/grok.rb
@@ -120,7 +120,7 @@
   # [source,ruby]
   #     filter {
   #       grok {
-  #         patterns_dir => "./patterns"
+  #         patterns_dir => ["./patterns"]
   #         match => { "message" => "%{SYSLOGBASE} %{POSTFIX_QUEUEID:queue_id}: %{GREEDYDATA:syslog_message}" }
   #       }
   #     }


### PR DESCRIPTION
patterns_dir only accepts an array as input, but one of the examples used a regular string. This implied that it would allow non-array string input, which isn't the case.

Is there a way to update the documentation on the site for the old versions with this fix as well? Because, as it stands, this could confuse someone (e.g. me) who, using an old version of logstash/grok, checks the documentation for that particular version.