### PR TITLE
Add test for correct JSON serialisation after grok

### DIFF
--- a/spec/filters/grok_spec.rb
+++ b/spec/filters/grok_spec.rb
@@ -772,4 +772,19 @@ describe LogStash::Filters::Grok do
     end
   end
 
+  describe "after grok when the event is JSON serialised the field values are unchanged" do
+    config <<-CONFIG
+      filter {grok {match => ["message", "Failed password for (invalid user |)%{USERNAME:username} from %{IP:src_ip} port %{BASE10NUM:port}"] remove_field => ["message","severity"] add_tag => ["ssh_failure"]}}
+    CONFIG
+
+    sample('{"facility":"auth","message":"Failed password for testuser from 1.1.1.1 port 22"}') do
+      insist { subject["username"] } == "testuser"
+      insist { subject["port"] } == "22"
+      insist { subject["src_ip"] } == "1.1.1.1"
+      insist { LogStash::Json.dump(subject['username']) } == "\"testuser\""
+
+      insist { subject.to_json } =~ %r|{"@version":"1","@timestamp":"20\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ","username":"testuser","src_ip":"1.1.1.1","port":"22","tags":\["ssh_failure"\]}|
+    end
+  end
+
 end


### PR DESCRIPTION
with JrJackson v 0.3.5 this test should fail.  Fixed with JrJackson v 0.3.6.

Reviewer:
If you run this tests locally make sure the version logstash-core includes newer version of JrJackson because some earlier releases of 2.0 have JrJackson 0.2.9 which will not fail the test.