### PR TITLE
Feature allow glob pattern for patterns_dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 Gemfile.lock
 .bundle
 vendor
+*.swp


### PR DESCRIPTION
Added the possibility to specify a glob pattern for the pattern files in patterns_dir.

May be a solution for #33, without breaking compatibility.