### PR TITLE
Add new timeout_millis/tag_on_timeout option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.2.0
+  - Add new timeout options to cancel grok execution if a threshold time is exceeded
+
 ## 3.1.2
   - Relax constraint on logstash-core-plugin-api to >= 1.60 <= 2.99
 

--- a/lib/logstash/filters/grok/timeout_enforcer.rb
+++ b/lib/logstash/filters/grok/timeout_enforcer.rb
@@ -1,0 +1,77 @@
+class LogStash::Filters::Grok::TimeoutEnforcer
+  def initialize(logger, timeout_nanos)
+    @logger = logger
+    @running = true
+    @timeout_nanos = timeout_nanos
+
+    # Stores running matches with their start time, this is used to cancel long running matches
+    # Is a map of Thread => start_time
+    @timer_mutex = Mutex.new
+    @threads_to_start_time = {}        
+  end
+
+  def grok_till_timeout(event, grok, field, value)
+    begin
+      thread = Thread.current
+      start_thread_groking(thread)
+      yield
+    rescue ::LogStash::Filters::Grok::TimeoutException => e
+      # These fields aren't present at the time the exception was raised
+      # so we add them here.
+      # We could store this metadata in the @threads_to_start_time hash
+      # but that'd come at a perf cost and this works just as well.
+      e.grok = grok
+      e.field = field
+      e.value = value
+      raise e
+    ensure
+      stop_thread_groking(thread)
+    end
+  end
+
+  def start_thread_groking(thread)
+    @timer_mutex.synchronize do
+      @threads_to_start_time[thread] = java.lang.System.nanoTime()
+    end
+  end
+
+  def stop_thread_groking(thread)
+    @timer_mutex.synchronize do
+      @threads_to_start_time.delete(thread)
+    end
+  end
+
+  def cancel_timed_out!
+    @threads_to_start_time.each do |thread,start_time|
+      now = java.lang.System.nanoTime # save ourselves some nanotime calls
+      elapsed = java.lang.System.nanoTime - start_time
+      if elapsed > @timeout_nanos
+        elapsed_millis = elapsed / 1000
+        thread.raise(::LogStash::Filters::Grok::TimeoutException.new(elapsed_millis))
+      end
+    end
+  end
+
+  def start!
+    @timer_thread = Thread.new do
+      while @running
+        begin
+          cancel_timed_out!
+        rescue Exception => e
+          @logger.error("Error while attempting to check/cancel excessively long grok patterns",
+                        :message => e.message,
+                        :class => e.class.name,
+                        :backtrace => e.backtrace
+                       )
+        end                   
+        sleep 0.25
+      end
+    end
+  end
+
+  def stop!
+    @running = false
+    # Check for the thread mostly for a fast start/shutdown scenario
+    @timer_thread.join if @timer_thread
+  end
+end

--- a/lib/logstash/filters/grok/timeout_exception.rb
+++ b/lib/logstash/filters/grok/timeout_exception.rb
@@ -1,0 +1,23 @@
+class LogStash::Filters::Grok::TimeoutException < Exception
+  attr_accessor :elapsed_millis, :grok, :field, :value
+  
+  def initialize(elapsed_millis, grok=nil, field=nil, value=nil)
+    @elapsed_millis = elapsed_millis
+    @field = field
+    @value = value
+    @grok = grok
+  end
+
+  def message
+    "Timeout executing grok '#{@grok.pattern}' against field '#{field}' with value '#{trunc_value}'!"
+  end
+
+  def trunc_value
+    if value.size <= 255 # If no more than 255 chars
+      value
+    else
+      "Value too large to output (#{value.bytesize} bytes)! First 255 chars are: #{value[0..255]}"
+    end
+  end
+end
+

--- a/logstash-filter-grok.gemspec
+++ b/logstash-filter-grok.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-grok'
-  s.version         = '3.1.2'
+  s.version         = '3.2.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Parse arbitrary text and structure it."
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
 
-  s.add_runtime_dependency 'jls-grok', '~> 0.11.1'
+  s.add_runtime_dependency 'jls-grok', '~> 0.11.3'
   s.add_runtime_dependency 'logstash-patterns-core'
 
   s.add_development_dependency 'logstash-devutils'


### PR DESCRIPTION
Resolves #82 .

As a note, the logic in the 'filter' function was convoluted before this patch,
and is now even more so. Perhaps some refactoring could improve this, but that might necessitate
changing grok behavior.

This PR needs more unit tests for the new TimeoutEnforcer class before it is no longer a WIP