### PR TITLE
Fix race in timeout exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-## 3.2.2
+## 3.2.3
+  - No longer use 'trace' log level as it breaks rspec
+  - Fix race conditions in timeout enforcer
+
+## 3.2.3
   - Move one log message from info to debug to avoid noise
 
 ## 3.2.1

--- a/lib/logstash/filters/grok/timeout_exception.rb
+++ b/lib/logstash/filters/grok/timeout_exception.rb
@@ -1,8 +1,7 @@
 class LogStash::Filters::Grok::TimeoutException < Exception
-  attr_accessor :elapsed_millis, :grok, :field, :value
+  attr_reader :grok, :field, :value
   
-  def initialize(elapsed_millis, grok=nil, field=nil, value=nil)
-    @elapsed_millis = elapsed_millis
+  def initialize(grok=nil, field=nil, value=nil)
     @field = field
     @value = value
     @grok = grok
@@ -20,4 +19,3 @@ class LogStash::Filters::Grok::TimeoutException < Exception
     end
   end
 end
-

--- a/logstash-filter-grok.gemspec
+++ b/logstash-filter-grok.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-grok'
-  s.version         = '3.2.2'
+  s.version         = '3.2.3'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Parse arbitrary text and structure it."
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
@@ -27,4 +27,3 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'logstash-devutils'
 end
-


### PR DESCRIPTION
 Previously we could see errors as in #95 due to some very esoteric race conditions where Thread#raise would raise outside of the rescue context. This patch changes the mechanism to be setting Thread.interrupt which is more robust.