### PR TITLE
Fix mutex exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.2.4
+  - Fix mutex interruption bug that could crash logstash. See: https://github.com/logstash-plugins/logstash-filter-grok/issues/97
+
 ## 3.2.3
   - No longer use 'trace' log level as it breaks rspec
   - Fix race conditions in timeout enforcer

--- a/logstash-filter-grok.gemspec
+++ b/logstash-filter-grok.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-grok'
-  s.version         = '3.2.3'
+  s.version         = '3.2.4'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Parse arbitrary text and structure it."
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
 Fix Uncaught Mutex Interrupt Exceptions

The TimeoutEnforcer used ruby's Mutex class which is interruptible  and throws a special exception. This switches the code to use  ReentrantLock (which JRuby's Mutex is based on) directly, and use ReentrantLock.lock instead of ReentrantLock.lockInterruptibly

This also adds a small note about the placement of thread.interrupted.

Fixes https://github.com/logstash-plugins/logstash-filter-grok/issues/97

This also makes dangerous TimeoutEnforcer methods private

Some timeout enforcer methods must be called in a specific sequence. This makes these methods explicitly private in order to prevent future programmers from attempting to use them directly