### PR TITLE
Change default timeout / Allow timeout to be disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.3.0
+  - Allow timeout enforcer to be disabled by setting timeout_millis to nil
+  - Change default timeout_millis to 30s
+
 ## 3.2.4
   - Fix mutex interruption bug that could crash logstash. See: https://github.com/logstash-plugins/logstash-filter-grok/issues/97
 

--- a/lib/logstash/filters/grok.rb
+++ b/lib/logstash/filters/grok.rb
@@ -199,7 +199,7 @@
     # This applies per pattern if multiple patterns are applied
     # This will never timeout early, but may take a little longer to timeout.
     # Actual timeout is approximate based on a 250ms quantization.
-    config :timeout_millis, :validate => :number, :default => 2000
+    config :timeout_millis, :validate => :number, :default => 30000
 
     # Tag to apply if a grok regexp times out.
     config :tag_on_timeout, :validate => :string, :default => '_groktimeout'
@@ -300,7 +300,7 @@
       end
 
       @logger.debug? and @logger.debug("Event now: ", :event => event)
-    rescue ::LogStash::Filters::Grok::TimeoutException => e      
+    rescue ::LogStash::Filters::Grok::TimeoutException => e
       @logger.warn(e.message)
       metric.increment(:timeouts)
       event.tag(@tag_on_timeout)

--- a/lib/logstash/filters/grok.rb
+++ b/lib/logstash/filters/grok.rb
@@ -199,6 +199,7 @@
     # This applies per pattern if multiple patterns are applied
     # This will never timeout early, but may take a little longer to timeout.
     # Actual timeout is approximate based on a 250ms quantization.
+    # Set to 0 to disable timeouts
     config :timeout_millis, :validate => :number, :default => 30000
 
     # Tag to apply if a grok regexp times out.
@@ -238,7 +239,7 @@
       @handlers = {}
 
       @timeout_enforcer = TimeoutEnforcer.new(@logger, @timeout_millis * 1000000)
-      @timeout_enforcer.start!
+      @timeout_enforcer.start! unless @timeout_millis == 0
     end
 
     public

--- a/lib/logstash/filters/grok/timeout_enforcer.rb
+++ b/lib/logstash/filters/grok/timeout_enforcer.rb
@@ -5,7 +5,7 @@ class LogStash::Filters::Grok::TimeoutEnforcer
 
   def initialize(logger, timeout_nanos)
     @logger = logger
-    @running = true
+    @running = false
     @timeout_nanos = timeout_nanos
 
     # Stores running matches with their start time, this is used to cancel long running matches
@@ -32,6 +32,7 @@ class LogStash::Filters::Grok::TimeoutEnforcer
   end
 
   def start!
+    @running = true
     @timer_thread = Thread.new do
       while @running
         begin

--- a/logstash-filter-grok.gemspec
+++ b/logstash-filter-grok.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-grok'
-  s.version         = '3.2.4'
+  s.version         = '3.3.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Parse arbitrary text and structure it."
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/filters/grok_spec.rb
+++ b/spec/filters/grok_spec.rb
@@ -409,9 +409,9 @@ describe LogStash::Filters::Grok do
 
   describe "timeout on failure" do
     config <<-CONFIG
-      filter { 
+      filter {
         grok {
-          match => { 
+          match => {
             message => "(.*a){30}"
           }
           timeout_millis => 100
@@ -821,13 +821,26 @@ describe LogStash::Filters::Grok do
     end
   end
 
-  describe "closing" do    
+  describe "opening/closing" do
+    let(:config) { {"match" => {"message" => "A"}} }
     subject(:plugin) do
-      ::LogStash::Filters::Grok.new("match" => {"message" => "A"})
+      ::LogStash::Filters::Grok.new(config)
     end
 
     before do
       plugin.register
+    end
+
+    it "should start the timeout enforcer" do
+      expect(plugin.timeout_enforcer.running).to be true
+    end
+
+    context "with the timeout enforcer disabled" do
+      let(:config) { super.merge("timeout_millis" => 0) }
+
+      it "should not start the timeout enforcer" do
+        expect(plugin.timeout_enforcer.running).to be false
+      end
     end
 
     it "should close cleanly" do


### PR DESCRIPTION
As seen in #99 sometimes there may be cases where the 2s timeout is too short. 30s is a more sane default. We should also allow timeouts to be disabled in case it does turn out to be a race condition after all we want people to be able to disable the feature without an upgrade. Also, some people may never want to time out.