### PR TITLE
Indicate that grok patterns are loaded when the pipeline is created

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.3.1
+  - Docs: indicate that grok patterns are loaded when the pipeline is created
+
 ## 3.3.0
   - Allow timeout enforcer to be disabled by setting timeout_millis to nil
   - Change default timeout_millis to 30s

--- a/lib/logstash/filters/grok.rb
+++ b/lib/logstash/filters/grok.rb
@@ -163,7 +163,7 @@
     # necessarily need to define this yourself unless you are adding additional
     # patterns. You can point to multiple pattern directories using this setting.
     # Note that Grok will read all files in the directory matching the patterns_files_glob
-    # and assume it's a pattern file (including any tilde backup files)
+    # and assume it's a pattern file (including any tilde backup files). 
     # [source,ruby]
     #     patterns_dir => ["/opt/logstash/patterns", "/opt/logstash/extra_patterns"]
     #
@@ -174,6 +174,8 @@
     # For example:
     # [source,ruby]
     #     NUMBER \d+
+    #
+    # The patterns are loaded when the pipeline is created.
     config :patterns_dir, :validate => :array, :default => []
 
     # Glob pattern, used to select the pattern files in the directories

--- a/logstash-filter-grok.gemspec
+++ b/logstash-filter-grok.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-grok'
-  s.version         = '3.3.0'
+  s.version         = '3.3.1'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Parse arbitrary text and structure it."
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Additional fix for https://github.com/elastic/logstash/pull/6261

