### PR TITLE
Trivial update to grok.rb

### DIFF
--- a/lib/logstash/filters/grok.rb
+++ b/lib/logstash/filters/grok.rb
@@ -7,7 +7,7 @@
 
   # Parse arbitrary text and structure it.
   #
-  # Grok is currently the best way in logstash to parse crappy unstructured log
+  # Grok is currently the best way in logstash to parse unstructured log
   # data into something structured and queryable.
   #
   # This tool is perfect for syslog logs, apache and other webserver logs, mysql


### PR DESCRIPTION
Remove unkind adjective of 'crappy' when describing unstructured log data. 
Before:
   # Grok is currently the best way in logstash to parse crappy unstructured log
After:
   # Grok is currently the best way in logstash to parse unstructured log

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
