### PR TITLE
# 110 Globs that Return Subdirectories Error out

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ Gemfile.lock
 .bundle
 vendor
 *.swp
+.idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.4.1
+  - Fix subdirectories in a pattern folder causing an exception in some cases
+
 ## 3.4.0
   - Add option to define patterns inline in the filter using `pattern_definitions` configuration.
 

--- a/lib/logstash/filters/grok.rb
+++ b/lib/logstash/filters/grok.rb
@@ -390,7 +390,11 @@
 
         Dir.glob(path).each do |file|
           @logger.trace("Grok loading patterns from file", :path => file)
-          patternfiles << file unless File.directory?(file)
+          if File.directory?(file)
+            @logger.debug("Skipping path because it is a directory", :path => file)
+          else
+            patternfiles << file
+          end
         end
       end
       patternfiles

--- a/lib/logstash/filters/grok.rb
+++ b/lib/logstash/filters/grok.rb
@@ -138,7 +138,7 @@
   # `SYSLOGBASE` pattern which itself is defined by other patterns.
   #
   # Another option is to define patterns _inline_ in the filter using `pattern_definitions`.
-  # This is mostly for convenience and allows user to define a pattern which can be used just in that
+  # This is mostly for convenience and allows user to define a pattern which can be used just in that 
   # filter. This newly defined patterns in `pattern_definitions` will not be available outside of that particular `grok` filter.
   #
   class LogStash::Filters::Grok < LogStash::Filters::Base
@@ -168,7 +168,7 @@
     # necessarily need to define this yourself unless you are adding additional
     # patterns. You can point to multiple pattern directories using this setting.
     # Note that Grok will read all files in the directory matching the patterns_files_glob
-    # and assume it's a pattern file (including any tilde backup files).
+    # and assume it's a pattern file (including any tilde backup files). 
     # [source,ruby]
     #     patterns_dir => ["/opt/logstash/patterns", "/opt/logstash/extra_patterns"]
     #
@@ -183,9 +183,9 @@
     # The patterns are loaded when the pipeline is created.
     config :patterns_dir, :validate => :array, :default => []
 
-    # A hash of pattern-name and pattern tuples defining custom patterns to be used by
-    # the current filter. Patterns matching existing names will override the pre-existing
-    # definition. Think of this as inline patterns available just for this definition of
+    # A hash of pattern-name and pattern tuples defining custom patterns to be used by 
+    # the current filter. Patterns matching existing names will override the pre-existing 
+    # definition. Think of this as inline patterns available just for this definition of 
     # grok
     config :pattern_definitions, :validate => :hash, :default => {}
 
@@ -237,7 +237,7 @@
     config :overwrite, :validate => :array, :default => []
 
     attr_reader :timeout_enforcer
-
+    
     # Register default pattern paths
     @@patterns_path ||= Set.new
     @@patterns_path += [
@@ -298,7 +298,7 @@
 
       @patterns.each do |field, groks|
         success = match(groks, field, event)
-
+        
         if success
           matched = true
           break if @break_on_match
@@ -337,7 +337,7 @@
       @logger.warn("Grok regexp threw exception", :exception => e.message, :backtrace => e.backtrace, :class => e.class.name)
       return false
     end
-
+    
     private
     def match_against_groks(groks, field, input, event)
       input = input.to_s
@@ -351,7 +351,7 @@
           break if @break_on_match
         end
       end
-
+      
       matched
     end
 

--- a/lib/logstash/filters/grok.rb
+++ b/lib/logstash/filters/grok.rb
@@ -138,7 +138,7 @@
   # `SYSLOGBASE` pattern which itself is defined by other patterns.
   #
   # Another option is to define patterns _inline_ in the filter using `pattern_definitions`.
-  # This is mostly for convenience and allows user to define a pattern which can be used just in that 
+  # This is mostly for convenience and allows user to define a pattern which can be used just in that
   # filter. This newly defined patterns in `pattern_definitions` will not be available outside of that particular `grok` filter.
   #
   class LogStash::Filters::Grok < LogStash::Filters::Base
@@ -168,7 +168,7 @@
     # necessarily need to define this yourself unless you are adding additional
     # patterns. You can point to multiple pattern directories using this setting.
     # Note that Grok will read all files in the directory matching the patterns_files_glob
-    # and assume it's a pattern file (including any tilde backup files). 
+    # and assume it's a pattern file (including any tilde backup files).
     # [source,ruby]
     #     patterns_dir => ["/opt/logstash/patterns", "/opt/logstash/extra_patterns"]
     #
@@ -183,9 +183,9 @@
     # The patterns are loaded when the pipeline is created.
     config :patterns_dir, :validate => :array, :default => []
 
-    # A hash of pattern-name and pattern tuples defining custom patterns to be used by 
-    # the current filter. Patterns matching existing names will override the pre-existing 
-    # definition. Think of this as inline patterns available just for this definition of 
+    # A hash of pattern-name and pattern tuples defining custom patterns to be used by
+    # the current filter. Patterns matching existing names will override the pre-existing
+    # definition. Think of this as inline patterns available just for this definition of
     # grok
     config :pattern_definitions, :validate => :hash, :default => {}
 
@@ -237,7 +237,7 @@
     config :overwrite, :validate => :array, :default => []
 
     attr_reader :timeout_enforcer
-    
+
     # Register default pattern paths
     @@patterns_path ||= Set.new
     @@patterns_path += [
@@ -298,7 +298,7 @@
 
       @patterns.each do |field, groks|
         success = match(groks, field, event)
-        
+
         if success
           matched = true
           break if @break_on_match
@@ -337,7 +337,7 @@
       @logger.warn("Grok regexp threw exception", :exception => e.message, :backtrace => e.backtrace, :class => e.class.name)
       return false
     end
-    
+
     private
     def match_against_groks(groks, field, input, event)
       input = input.to_s
@@ -351,7 +351,7 @@
           break if @break_on_match
         end
       end
-      
+
       matched
     end
 
@@ -390,7 +390,7 @@
 
         Dir.glob(path).each do |file|
           @logger.trace("Grok loading patterns from file", :path => file)
-          patternfiles << file
+          patternfiles << file unless File.directory?(file)
         end
       end
       patternfiles

--- a/lib/logstash/filters/grok/timeout_enforcer.rb
+++ b/lib/logstash/filters/grok/timeout_enforcer.rb
@@ -11,7 +11,7 @@ class LogStash::Filters::Grok::TimeoutEnforcer
     # Stores running matches with their start time, this is used to cancel long running matches
     # Is a map of Thread => start_time
     @threads_to_start_time = {}
-    @state_lock = java.util.concurrent.locks.ReentrantLock.new
+    @state_lock = ReentrantLock.new
   end
 
   def grok_till_timeout(event, grok, field, value)

--- a/logstash-filter-grok.gemspec
+++ b/logstash-filter-grok.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
 
   s.add_runtime_dependency 'jls-grok', '~> 0.11.3'
+  s.add_runtime_dependency 'stud', '~> 0.0.22'
   s.add_runtime_dependency 'logstash-patterns-core'
 
   s.add_development_dependency 'logstash-devutils'

--- a/logstash-filter-grok.gemspec
+++ b/logstash-filter-grok.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-grok'
-  s.version         = '3.4.0'
+  s.version         = '3.4.1'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Parse arbitrary text and structure it."
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
closes #110 

* Fixed by https://github.com/logstash-plugins/logstash-filter-grok/compare/master...original-brownbear:110?expand=1#diff-0d9c333ff736a82e8686ba9c4bb5e919L393
   * Since this is all private methods we need to just make sure that globbing for files won't return directories too
* Added test
* 2 small cleanups (gitignore `.idea` + autocleanup redundant qualifier on Java import)  