### PR TITLE
Add link to grok debugger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.4.3
+  - Docs: Add link to Grok Debugger tool
+
 ## 3.4.1
   - Fix subdirectories in a pattern folder causing an exception in some cases
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -34,7 +34,9 @@ Logstash ships with about 120 patterns by default. You can find them here:
 your own trivially. (See the `patterns_dir` setting)
 
 If you need help building patterns to match your logs, you will find the
-<http://grokdebug.herokuapp.com> and <http://grokconstructor.appspot.com/> applications quite useful!
+https://www.elastic.co/guide/en/kibana/current/xpack-grokdebugger.html[Grok Debugger]
+tool quite useful! The Grok Debugger is an X-Pack feature under the Basic License and is
+therefore *free to use*.
 
 ==== Grok Basics
 

--- a/logstash-filter-grok.gemspec
+++ b/logstash-filter-grok.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-grok'
-  s.version         = '3.4.2'
+  s.version         = '3.4.3'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Parse arbitrary text and structure it."
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Note that the link won't work until the 5.5 docs are live, so I didn't add the link earlier. This means that the link won't be visible until we publish the docs for the next release.