### PR TITLE
Update index.asciidoc

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -32,8 +32,8 @@ Logstash ships with about 120 patterns by default. You can find them here:
 <https://github.com/logstash-plugins/logstash-patterns-core/tree/master/patterns>. You can add
 your own trivially. (See the `patterns_dir` setting)
 
-If you need help building patterns to match your logs, you will find the
-<http://grokdebug.herokuapp.com> and <http://grokconstructor.appspot.com/> applications quite useful!
+If you need help building patterns to match your logs, Kibana has an inbuilt [Grok Debugger](https://www.elastic.co/guide/en/kibana/current/xpack-grokdebugger.html) you
+can use!
 
 ==== Grok Basics
 


### PR DESCRIPTION
Now pointing users to the inbuilt grok debugger in Kibana :)

Only applies to 5.5 onwards though, so please don't back port to anything prior.