### PR TITLE
PERFORMANCE: Fix slow metric invocation and needless locking on timeout enforcer

### DIFF
--- a/logstash-filter-grok.gemspec
+++ b/logstash-filter-grok.gemspec
@@ -26,5 +26,5 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'stud', '~> 0.0.22'
   s.add_runtime_dependency 'logstash-patterns-core'
 
-  s.add_development_dependency 'logstash-devutils', '= 1.3.4'
+  s.add_development_dependency 'logstash-devutils', '= 1.3.6'
 end

--- a/logstash-filter-grok.gemspec
+++ b/logstash-filter-grok.gemspec
@@ -26,5 +26,5 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'stud', '~> 0.0.22'
   s.add_runtime_dependency 'logstash-patterns-core'
 
-  s.add_development_dependency 'logstash-devutils'
+  s.add_development_dependency 'logstash-devutils', '= 1.3.4'
 end


### PR DESCRIPTION
This is a more than a `100%` speedup for me relative to `master` when testing against the test configuration posted here https://github.com/elastic/logstash/issues/8560#issue-270112018.

I know Travis will probably go red on this one, but it's not broken functionally :) see below:

* Fixed slow metric API use (see https://github.com/elastic/logstash/pull/7919), this is the biggest part of the speedup and makes execution twice as fast right off the bat (makes Grok incompatible with versions before https://github.com/elastic/logstash/pull/7941 though :( ... I think that means before `5.6.2` but have to check later) If we don't want to break BwC I could work around things (just use a per-thread counter for the metrics and increment the metrics every now and then works as well, just more code) 
* Fixed the whole thread map to be lock-free by using a concurrent hashmap (~20% speedup from this on the test config) 
* Removed `yield`(/dynamic block creation) from the timeout grok method and just used an outright method call there (mostly saving memory here, not much throughput gain in my tests)
* Actually saved calls to `java.lang.System.nanoTime` :), `now` was unused
* Inlined away `success` (trivial but in JRuby this actually saves memory :D)

