### PR TITLE
 #127 fix test randomly failing from incorrect assumption about key order in JSON hash

### DIFF
--- a/spec/filters/grok_spec.rb
+++ b/spec/filters/grok_spec.rb
@@ -889,7 +889,7 @@ describe LogStash::Filters::Grok do
       insist { subject.to_json } =~ %r|"@version":"1"|
       insist { subject.to_json } =~ %r|"username"|i
       insist { subject.to_json } =~ %r|"testuser"|
-      insist { subject.to_json } =~ %r|"tags":\["ssh_failure"\]}|
+      insist { subject.to_json } =~ %r|"tags":\["ssh_failure"\]|
     end
   end
 


### PR DESCRIPTION
Fixes random test failures described in #127. 

The failures happen when `tags` is not the last key in the generated `json`, which is not guaranteed to be so (but seems to happen every time with older JrJackson/LS versions, not so with `master` and `6.x`).

=> Simply fix the string matcher to not assume `tags` to be followed by the closing `}`.