### PR TITLE
Refactor initialization to prevent a resource leak.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.0.2
+  - Fixed resource leak where this plugin might get double initialized during plugin reload, leaking a thread + some objects
+
 ## 4.0.1
   - Fix a potential race
 

--- a/lib/logstash/filters/grok.rb
+++ b/lib/logstash/filters/grok.rb
@@ -3,6 +3,7 @@
   require "logstash/namespace"
   require "logstash/environment"
   require "logstash/patterns/core"
+  require "grok-pure" # rubygem 'jls-grok'
   require "set"
 
   # Parse arbitrary text and structure it.
@@ -246,18 +247,12 @@
     ]
 
     public
-    def initialize(params)
-      super(params)
+    def register
       # a cache of capture name handler methods.
       @handlers = {}
 
       @timeout_enforcer = TimeoutEnforcer.new(@logger, @timeout_millis * 1000000)
       @timeout_enforcer.start! unless @timeout_millis == 0
-    end
-
-    public
-    def register
-      require "grok-pure" # rubygem 'jls-grok'
 
       @patternfiles = []
 

--- a/logstash-filter-grok.gemspec
+++ b/logstash-filter-grok.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-grok'
-  s.version         = '4.0.1'
+  s.version         = '4.0.2'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Parses unstructured event data into fields"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Plugins generally shouldn't call initialize. While LS core could be improved this small fix is worthwhile today.

Fixes https://github.com/logstash-plugins/logstash-filter-grok/issues/132 .