### PR TITLE
fix memory leak on JRuby 1.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.0.3
+  - Fixed memory leak when run on JRuby 1.x (Logstash 5.x) [#135](https://github.com/logstash-plugins/logstash-filter-grok/issues/135)
+  
 ## 4.0.2
   - Fixed resource leak where this plugin might get double initialized during plugin reload, leaking a thread + some objects
 

--- a/lib/logstash/filters/grok/timeout_enforcer.rb
+++ b/lib/logstash/filters/grok/timeout_enforcer.rb
@@ -56,7 +56,7 @@ class LogStash::Filters::Grok::TimeoutEnforcer
 
   def cancel_timed_out!
     now = java.lang.System.nanoTime # save ourselves some nanotime calls
-    @threads_to_start_time.forEach do |thread, start_time|
+    @threads_to_start_time.keySet.each do |thread|
       # Use compute to lock this value
       @threads_to_start_time.computeIfPresent(thread) do |thread, start_time|
         if start_time < now && now - start_time > @timeout_nanos

--- a/logstash-filter-grok.gemspec
+++ b/logstash-filter-grok.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-grok'
-  s.version         = '4.0.2'
+  s.version         = '4.0.3'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Parses unstructured event data into fields"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
It seems that on JRuby 1.x (tested jruby-1.7.27), the outer loop when coded as Java forEach causes JRuby to leak some internal state. Specifically the NonBlockingHashMapLong$CHM dominates the memory. See the referenced bug for a reproduction case. The commit changes the outer loop to a standard for loop to avoid this bug.

Fixes #135

