### PR TITLE
Grok debuggers and type conversions noted

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -34,6 +34,8 @@ your own trivially. (See the `patterns_dir` setting)
 
 If you need help building patterns to match your logs, you will find the
 <http://grokdebug.herokuapp.com> and <http://grokconstructor.appspot.com/> applications quite useful!
+Note however that data type conversion to `int` is logstash only - do not expect this to work
+within these debuggers.
 
 ==== Grok Basics
 


### PR DESCRIPTION
The grok debuggers do not accept the logstash `:int ` conversion. Had me confused for ages.

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
