### PR TITLE
Test: tunings for green(er) ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,7 @@ import:
 env:
   global:
   - HAS_PERFORMANCE_TESTS=1
+
+allow_failures:
+  - name: Performance
+    if: type = cron

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,3 @@ import:
 env:
   global:
   - HAS_PERFORMANCE_TESTS=1
-
-allow_failures:
-  - name: Performance
-    if: type = cron

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,5 @@ import:
 
 env:
   global:
-  - HAS_PERFORMANCE_TESTS=1
+  # disabled running performance tests on CI
+  - HAS_PERFORMANCE_TESTS=0

--- a/spec/filters/grok_performance_spec.rb
+++ b/spec/filters/grok_performance_spec.rb
@@ -21,13 +21,7 @@ describe LogStash::Filters::Grok do
 
   describe "base-line performance", :performance => true do
 
-    EXPECTED_MIN_RATE = 15_000 # per second
-    # NOTE: based on Travis CI (docker) numbers :
-    # logstash_1_d010d1d29244 | LogStash::Filters::Grok
-    # logstash_1_d010d1d29244 |   base-line performance
-    # logstash_1_d010d1d29244 | filters/grok parse rate: 14464/sec, elapsed: 20.740866999999998s
-    # logstash_1_d010d1d29244 | filters/grok parse rate: 29957/sec, elapsed: 10.014199s
-    # logstash_1_d010d1d29244 | filters/grok parse rate: 32932/sec, elapsed: 9.109601999999999s
+    EXPECTED_MIN_RATE = 30_000 # per second - based on Travis CI (docker) numbers
 
     let(:config) do
       { 'match' => { "message" => "%{SYSLOGLINE}" }, 'overwrite' => [ "message" ] }

--- a/spec/filters/grok_performance_spec.rb
+++ b/spec/filters/grok_performance_spec.rb
@@ -100,12 +100,14 @@ describe LogStash::Filters::Grok do
       with_timeout_duration = do_sample_filter(filter_with_timeout) # warmup
       puts "filters/grok(timeout_scope => event) warmed up in #{with_timeout_duration}"
 
-      before_sample!
-      expect do
-        duration = do_sample_filter(filter_with_timeout)
-        puts "filters/grok(timeout_scope => event) took #{duration}"
-        duration
-      end.to perform_under(expected_duration).sample(SAMPLE_COUNT).times
+      try(3) do
+        before_sample!
+        expect do
+          duration = do_sample_filter(filter_with_timeout)
+          puts "filters/grok(timeout_scope => event) took #{duration}"
+          duration
+        end.to perform_under(expected_duration).sample(SAMPLE_COUNT).times
+      end
     end
 
     @private

--- a/spec/filters/grok_spec.rb
+++ b/spec/filters/grok_spec.rb
@@ -393,15 +393,17 @@ describe LogStash::Filters::Grok do
           "message" => [
             "(.*f){20}", "(.*e){20}", "(.*d){20}", "(.*c){20}", "(.*b){20}",
             "(.*a){25}", "(.*a){24}", "(.*a){23}", "(.*a){22}", "(.*a){21}",
+            "(.*a){25}", "(.*a){24}", "(.*a){23}", "(.*a){22}", "(.*a){21}",
+            "(.*a){25}", "(.*a){24}", "(.*a){23}", "(.*a){22}", "(.*a){21}",
             "(.*a){20}"
           ]
         },
-        'timeout_millis' => 500,
+        'timeout_millis' => 750,
         'timeout_scope' => 'pattern'
       }
     }
 
-    sample( 'b' * 10 + 'c' * 10 + 'd' * 10 + 'e' * 10 + ' ' + 'a' * 20 ) do
+    sample( 'b' * 15 + 'c' * 15 + 'd' * 15 + 'e' * 15 + ' ' + 'a' * 20 ) do
       expect( event.get("tags") ).to be nil
     end
   end
@@ -413,15 +415,17 @@ describe LogStash::Filters::Grok do
           "message" => [
             "(.*f){20}", "(.*e){20}", "(.*d){20}", "(.*c){20}", "(.*b){20}",
             "(.*a){25}", "(.*a){24}", "(.*a){23}", "(.*a){22}", "(.*a){21}",
+            "(.*a){25}", "(.*a){24}", "(.*a){23}", "(.*a){22}", "(.*a){21}",
+            "(.*a){25}", "(.*a){24}", "(.*a){23}", "(.*a){22}", "(.*a){21}",
             "(.*a){20}"
           ]
         },
-        'timeout_millis' => 500,
+        'timeout_millis' => 750,
         'timeout_scope' => 'event'
       }
     }
 
-    sample( 'b' * 10 + 'c' * 10 + 'd' * 10 + 'e' * 10 + ' ' + 'a' * 20 ) do
+    sample( 'b' * 15 + 'c' * 15 + 'd' * 15 + 'e' * 15 + ' ' + 'a' * 20 ) do
       expect( event.get("tags") ).to include("_groktimeout")
       expect( event.get("tags") ).not_to include("_grokparsefailure")
     end


### PR DESCRIPTION
timeout specs should now be more predictable, performance specs are still not that much useful on CI ...

NOTE: would still like to keep perf. specs around for comparison if I (ever) manage to finish the faster timeout library.