### PR TITLE
Revert doc link changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,3 @@
-## 4.4.1
- - [Doc] fix the broken link [#166](https://github.com/logstash-plugins/logstash-filter-grok/pull/166)
-
 ## 4.4.0
  - Feat: ECS compatibility support [#162](https://github.com/logstash-plugins/logstash-filter-grok/pull/162)
  

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -178,7 +178,7 @@ filter. This newly defined patterns in `pattern_definitions` will not be availab
 [id="plugins-{type}s-{plugin}-ecs"]
 ==== Migrating to Elastic Common Schema (ECS)
 
-To ease migration to the {ecs-ref}/index.html[Elastic Common Schema (ECS)], the filter
+To ease migration to the {ecs-ref}[Elastic Common Schema (ECS)], the filter
 plugin offers a new set of ECS-compliant patterns in addition to the existing
 patterns. The new ECS pattern definitions capture event field names that are
 compliant with the schema.
@@ -240,7 +240,7 @@ parsing different things), then set this to false.
 ** When Logstash provides a `pipeline.ecs_compatibility` setting, its value is used as the default
 ** Otherwise, the default value is `disabled`.
 
-Controls this plugin's compatibility with the {ecs-ref}/index.html[Elastic Common Schema (ECS)].
+Controls this plugin's compatibility with the {ecs-ref}[Elastic Common Schema (ECS)].
 The value of this setting affects extracted event field names when a composite pattern (such as `HTTPD_COMMONLOG`) is matched.
 
 [id="plugins-{type}s-{plugin}-keep_empty_captures"]

--- a/logstash-filter-grok.gemspec
+++ b/logstash-filter-grok.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-filter-grok'
-  s.version         = '4.4.1'
+  s.version         = '4.4.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Parses unstructured event data into fields"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Reverts recent doc changes and version bump. 

The correct fix is here:  https://github.com/elastic/logstash-docs/pull/986
