### PR TITLE
Clarify the definition of matches that depend on previous captures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 4.4.2
-  - Clarify the definition of matches that depend on previous captures [#169](https://api.github.com/repos/logstash-plugins/logstash-filter-grok/pulls/169)
+  - Clarify the definition of matches that depend on previous captures [#169](https://github.com/logstash-plugins/logstash-filter-grok/pull/169)
 
 ## 4.4.1
  - Added preview of ECS v8 support using existing ECS v1 implementation [#175](https://github.com/logstash-plugins/logstash-filter-grok/pull/175)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.4.1
+  - Clarify the definition of matches that depend on previous captures [#169](https://api.github.com/repos/logstash-plugins/logstash-filter-grok/pulls/169)
+
 ## 4.4.0
  - Feat: ECS compatibility support [#162](https://github.com/logstash-plugins/logstash-filter-grok/pull/162)
  

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -294,20 +294,8 @@ To perform matches on multiple fields just use multiple entries in the `match` h
       }
     }
 
-However, if one pattern depends on a field created by a previous pattern, separate these into two separate grok filters,
-as it is not guaranteed that the following will work:
+However, if one pattern depends on a field created by a previous pattern, separate these into two separate grok filters:
 
-[source,ruby]
-    filter {
-      grok {
-        match => {
-          "message" => "Hi, the rest of the message is: %{GREEDYDATA:rest}"
-          "rest => "a number %{NUMBER"number}, and a word %{WORD:word}"
-        }
-      }
-    }
-
-You should do instead:
 
 [source,ruby]
     filter {

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -281,6 +281,48 @@ If you need to match multiple patterns against a single field, the value can be 
         }
       }
     }
+    
+To perform matches on multiple fields just use multiple entries in the `match` hash:
+
+[source,ruby]
+    filter {
+      grok {
+        match => {
+          "speed" => "Speed: %{NUMBER:speed}"
+          "duration => "Duration: %{NUMBER:duration}"
+        }
+      }
+    }
+
+However, if one pattern depends on a field created by a previous pattern, separate these into two separate grok filters,
+as it is not guaranteed that the following will work:
+
+[source,ruby]
+    filter {
+      grok {
+        match => {
+          "message" => "Hi, the rest of the message is: %{GREEDYDATA:rest}"
+          "rest => "a number %{NUMBER"number}, and a word %{WORD:word}"
+        }
+      }
+    }
+
+You should do instead:
+
+[source,ruby]
+    filter {
+      grok {
+        match => {
+          "message" => "Hi, the rest of the message is: %{GREEDYDATA:rest}"
+        }
+      }
+      grok {
+        match => {
+          "rest => "a number %{NUMBER"number}, and a word %{WORD:word}"
+        }
+      }
+    }
+
 
 [id="plugins-{type}s-{plugin}-named_captures_only"]
 ===== `named_captures_only` 

--- a/logstash-filter-grok.gemspec
+++ b/logstash-filter-grok.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-filter-grok'
-  s.version         = '4.4.0'
+  s.version         = '4.4.1'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Parses unstructured event data into fields"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/logstash-filter-grok.gemspec
+++ b/logstash-filter-grok.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-filter-grok'
-  s.version         = '4.4.1'
+  s.version         = '4.4.2'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Parses unstructured event data into fields"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
When defining a match from a previous capture, we don't guarantee that the order of the match statements in 1 grok pattern is respected.
To make it clear that a pattern is creating a capture and that we want to match on it as well, the user should define two separate grok filters.