### PR TITLE
[DOC] Using field references in overwrite

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -313,13 +313,13 @@ overwrite the `message` field with part of the match like so:
 In this case, a line like `May 29 16:37:11 sadness logger: hello world`
 will be parsed and `hello world` will overwrite the original message.
 
-If you are using a field reference in `overwrite`, you should use the field 
-reference also in the pattern(s). Example:
+If you are using a field reference in `overwrite`, you must use the field 
+reference in the pattern. Example:
 [source,ruby]
     filter {
       grok {
-        match => { "somefield" => "%{DATA:[mymessage]}" }
-        overwrite => [ "[mymessage]" ]
+        match => { "somefield" => "%{NUMBER} %{GREEDYDATA:[nested][field][test]}" }
+        overwrite => [ "[nested][field][test]" ]
       }
     }
 


### PR DESCRIPTION
Example on how to use field references in overwrite and it requires being consistent (the field reference must be used also in the pattern).
