### PR TITLE
Removing outdated grok debugger links

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -32,8 +32,8 @@ Logstash ships with about 120 patterns by default. You can find them here:
 <https://github.com/logstash-plugins/logstash-patterns-core/tree/master/patterns>. You can add
 your own trivially. (See the `patterns_dir` setting)
 
-If you need help building patterns to match your logs, you will find the
-<http://grokdebug.herokuapp.com> and <http://grokconstructor.appspot.com/> applications quite useful!
+If you need help building patterns to match your logs, you will find the Grok Debugger in Kibana
+quite useful!
 
 ===== Grok or Dissect? Or both?
 


### PR DESCRIPTION
The grokdebugger.herokuapp link does not work any more; rather than linking to external sites that we have no control over (and have obviously not been maintained), it would be better to point to our own grok debugger that comes with Kibana. I'd like to make a link, but I'm not sure if there's any way to do a relative link to the latest kibana documentation...

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
