### PR TITLE
Fix failures when multiple patterns are specified and break_on_match is False

### DIFF
--- a/lib/logstash/filters/grok.rb
+++ b/lib/logstash/filters/grok.rb
@@ -376,19 +376,20 @@
       end
 
       def match(context, groks, event, break_on_match)
-        matched = false
+        matched = any_matched = false
 
         groks.each do |grok|
           context.set_grok(grok)
 
           matched = execute(context, grok)
+	  any_matched ||= matched
           if matched
             grok.capture(matched) { |field, value| @filter.handle(field, value, event) }
             break if break_on_match
           end
         end
 
-        matched
+        any_matched
       end
 
       protected


### PR DESCRIPTION
In the case where multiple match patterns were specified and `break_on_match` was `false`, Grok would mark eent as failed if last pattern did not match (even if any other pattern did). This PR fixes that problem and also adds tests for the same.

Closes #49

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
