### PR TITLE
ecs: remove warning when using v8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.4.4
+  - Removed warning about ECS v8 being a preview
+
 ## 4.4.3
   - Minor typos in docs examples [#176](https://github.com/logstash-plugins/logstash-filter-grok/pull/176)
 

--- a/lib/logstash/filters/grok.rb
+++ b/lib/logstash/filters/grok.rb
@@ -330,10 +330,8 @@
       case ecs_compatibility
       when :disabled
         patterns_path << LogStash::Patterns::Core.path # :legacy
-      when :v1
-        patterns_path << LogStash::Patterns::Core.path('ecs-v1')
-      when :v8
-        @logger.warn("ECS v8 support is a preview of the unreleased ECS v8, and uses the v1 patterns. When Version 8 of the Elastic Common Schema becomes available, this plugin will need to be updated")
+      when :v1, :v8
+        # v8 is an alias for v1; there were no relevant material changes to the schema
         patterns_path << LogStash::Patterns::Core.path('ecs-v1')
       else
         fail(NotImplementedError, "ECS #{ecs_compatibility} is not supported by this plugin.")

--- a/logstash-filter-grok.gemspec
+++ b/logstash-filter-grok.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-filter-grok'
-  s.version         = '4.4.3'
+  s.version         = '4.4.4'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Parses unstructured event data into fields"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/filters/grok_spec.rb
+++ b/spec/filters/grok_spec.rb
@@ -775,26 +775,6 @@ describe LogStash::Filters::Grok do
 end
 
 describe LogStash::Filters::Grok do
-
-  subject(:grok_filter) { described_class.new(config) }
-  let(:config) { {} }
-
-  context 'when initialized with `ecs_compatibility => v8`' do
-    let(:config) { super().merge("ecs_compatibility" => "v8", "match" => ["message", "%{SYSLOGLINE}"]) }
-    context '#register' do
-      let(:logger_stub) { double('Logger').as_null_object }
-      before(:each) { allow_any_instance_of(described_class).to receive(:logger).and_return(logger_stub)}
-
-      it 'logs a helpful warning about the unreleased v8' do
-        grok_filter.register
-
-        expect(logger_stub).to have_received(:warn).with(a_string_including "preview of the unreleased ECS v8")
-      end
-    end
-  end
-end
-
-describe LogStash::Filters::Grok do
   describe "(LEGACY)" do
     describe "patterns in the 'patterns/' dir override core patterns" do
 


### PR DESCRIPTION
In `logstash-patterns-core`, no distinct implementation was provided for `evs-v8` because it was effectively identical to `ecs-v1`. 

Remove the irrelevant warning.