### PR TITLE
Replace TravisCI with GHA

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -1,0 +1,12 @@
+name: Plugin Performance Tests
+
+on:
+  push:
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  performance:
+    uses: logstash-plugins/.ci/.github/workflows/performance.yml@1.x

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,22 @@
+name: Plugin Unit Tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  schedule:
+    # Run daily at 08:00 UTC on active branches
+    - cron: '0 8 * * *'
+  workflow_dispatch:
+
+jobs:
+  unit-tests:
+    uses: logstash-plugins/.ci/.github/workflows/unit-tests.yml@1.x
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+    with:
+      timeout-minutes: 60

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-import:
-- logstash-plugins/.ci:travis/travis.yml@1.x
-
-env:
-  global:
-  # disabled running performance tests on CI
-  - HAS_PERFORMANCE_TESTS=0


### PR DESCRIPTION
This commit replaces the tests run with travis to GHA. Note that while the performance tests are set to not run by default, they can be triggered via the GUI (or by enabling the env var in code). They were not being run by default with travis. This continues to be the case, but there is now the path forward to triggering a run with those.

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
