### PR TITLE
Add secrets: inherit to reusable workflow callers

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -10,3 +10,4 @@ on:
 jobs:
   performance:
     uses: logstash-plugins/.ci/.github/workflows/performance.yml@1.x
+    secrets: inherit

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -15,6 +15,7 @@ on:
 jobs:
   unit-tests:
     uses: logstash-plugins/.ci/.github/workflows/unit-tests.yml@1.x
+    secrets: inherit
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}


### PR DESCRIPTION
## What

Adds `secrets: inherit` to every reusable-workflow caller job in this repo's `.github/workflows/`.

## Why

The reusable workflows in `logstash-plugins/.ci` (`1.x`) now run a failure-notification step that reads `secrets.SLACK_BOT_TOKEN` (logstash-plugins/.ci#134). The reusables do **not** declare a `workflow_call.secrets:` block, so callers must pass `secrets: inherit` on each reusable-call job for the token to reach the notification step.

Without it the token is empty and Slack failure notifications silently never fire (tests otherwise pass). This change is a no-op for test execution; it only enables the failure-notification path.